### PR TITLE
Add CONTRIBUTING + docs roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thanks for your interest in contributing!
+
+This repo is a personal, non-commercial fan project. Contributions are welcome as long as they follow the non-commercial intent and keep copyrighted IP concerns in mind.
+
+## Quick rules
+
+- Be respectful and constructive.
+- Keep PRs small and focused.
+- Prefer discussion in an issue before large architectural changes.
+- Do not add copyrighted Robotech/Palladium assets to the repo.
+
+## Getting started
+
+### 1) Prereqs
+- Unity **2022.3 LTS** (see README for the exact version)
+- Git
+
+### 2) Clone
+```bash
+git clone https://github.com/MatthewSnow2/robotech-turn-based-game.git
+cd robotech-turn-based-game
+```
+
+### 3) Open in Unity
+Open the project via **Unity Hub**.
+
+## Workflow
+
+### Issues
+Use issues to track:
+- bugs
+- feature requests
+- design decisions / open questions
+
+### Pull Requests
+PRs can be for anything that changes the repo: docs, refactors, features, CI, etc.
+
+**PR checklist**
+- [ ] Clear title + description (what/why)
+- [ ] Small scope (one topic)
+- [ ] No secrets committed (licenses/tokens)
+- [ ] CI passes (if applicable)
+
+## Branch naming
+Use:
+- `chad/<topic>` for changes made by Chad
+- `feature/<topic>` for larger feature work
+- `fix/<topic>` for bug fixes
+
+## Non-commercial notice
+By contributing, you agree your contributions are also intended for non-commercial use.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,38 @@
+# Roadmap (WIP)
+
+This is a lightweight roadmap for the **Robotech - TBS** project. It’s intentionally flexible.
+
+## Phase 0 — Repo scaffolding
+- [ ] Confirm Unity version + project structure
+- [ ] Basic documentation (README, CONTRIBUTING, roadmap)
+- [ ] CI baseline (EditMode tests)
+
+## Phase 1 — Playable prototype loop
+Goal: a tiny slice that proves the core loop is fun.
+
+- [ ] Hex grid + terrain representation
+- [ ] Camera + selection
+- [ ] Turn system (2 factions)
+- [ ] A small unit set (e.g., 2–3 units per faction)
+- [ ] Basic combat resolution
+- [ ] Win condition: conquest-only
+
+## Phase 2 — Civ-like strategy layer
+- [ ] Cities + basic production
+- [ ] Districts (Factories, Labs, Outposts)
+- [ ] Resources (materials, credits, population, protoculture)
+- [ ] Fog of war / scouting
+
+## Phase 3 — AI opponents
+- [ ] Difficulty levels
+- [ ] Personalities (aggressive/defensive/economic)
+- [ ] Non-cheating baseline AI
+
+## Phase 4 — Polish
+- [ ] UX pass
+- [ ] Performance pass
+- [ ] Better tutorials / onboarding
+
+## Notes
+- Keep PRs small: one topic per PR.
+- Avoid committing any copyrighted IP assets.


### PR DESCRIPTION
Adds basic contributor guidelines and a lightweight project roadmap under docs/. This is a low-risk starter PR to establish repo hygiene and a repeatable PR workflow.